### PR TITLE
User endpoints implemented and tested

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,6 @@ Please note we have a code of conduct and it's simply 1 rule, don't be a dickhea
 - List comprehensions should always be used where possible unless the code is too ugly and readable, that is for you and the reviewer to agree with :-)
 
 # Tests
-to-do
 
 # Test Infrastructure
 to-do

--- a/poetry.lock
+++ b/poetry.lock
@@ -588,6 +588,20 @@ docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1.0)"]
 testing = ["coverage (>=6.2)", "hypothesis (>=5.7.1)"]
 
 [[package]]
+name = "pytest-order"
+version = "1.2.0"
+description = "pytest plugin to run your tests in a specific order"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "pytest-order-1.2.0.tar.gz", hash = "sha256:944f86b6d441aa7b1da80f801c6ab65b84bbeba472d0a7a12eb43ba26650101a"},
+    {file = "pytest_order-1.2.0-py3-none-any.whl", hash = "sha256:9d65c3b6dc6d6ee984d6ae2c6c4aa4f1331e5b915116219075c888c8bcbb93b8"},
+]
+
+[package.dependencies]
+pytest = {version = ">=6.2.4", markers = "python_version >= \"3.10\""}
+
+[[package]]
 name = "ruff"
 version = "0.1.9"
 description = "An extremely fast Python linter and code formatter, written in Rust."
@@ -741,4 +755,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "cfb9cc53dbcba8a7195d2895268fc875e7866384a9d262e5f6e1e65e08d38008"
+content-hash = "1b1ca29a23fc7e9233a03fbfcedfd8f5809e4c8fd6f28489cdc9a14216ffd718"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ aiohttp = "^3.9.1"
 pytest = "^7.4.3"
 ruff = "^0.1.9"
 pytest-aiohttp = "^1.0.5"
+pytest-order = "^1.2.0"
 
 
 [tool.poetry.group.pydantic.dependencies]

--- a/pyproxmox_ve/models/user.py
+++ b/pyproxmox_ve/models/user.py
@@ -1,34 +1,60 @@
-from typing import Optional
-from typing_extensions import Annotated
-from pydantic import Field
+from typing import Optional, Dict, Literal, Any
 from pyproxmox_ve.models.base import ProxmoxBaseModel
 
 
-class UserToken(ProxmoxBaseModel):
-    comment: Optional[str] = None
+class UserTokenBase(ProxmoxBaseModel):
     expire: Optional[int] = 0
-    privsep: Optional[bool] = True
-    tokenid: Optional[Annotated[str, Field(pattern="(^:[A-Za-z][A-Za-z0-9\\.\\-_]+)")]]
+    privsep: Optional[int] = 1
+
+
+class UserToken(UserTokenBase):
+    comment: Optional[str] = None
+    tokenid: Optional[str] = None
+
+
+class UserTokenResponse(ProxmoxBaseModel):
+    full_tokenid: str
+    info: dict
+    value: str
 
 
 class UserBase(ProxmoxBaseModel):
-    userid: str
+    userid: Optional[str] = None
     comment: Optional[str] = None
     email: Optional[str] = None
-    enable: Optional[bool] = None
+    enable: Optional[int] = None
     expire: Optional[int] = 0
     firstname: Optional[str] = None
-    groups: Optional[str] = None
+    groups: Optional[list[str] | str] = None
     keys: Optional[list[str]] = []
     lastname: Optional[str] = None
 
 
 class UserCreate(UserBase):
+    userid: str
     password: Optional[str] = None
+
+
+class UserUpdate(UserBase):
+    append: Optional[int] = None
+
+
+class UserUniqueToken(UserTokenBase):
+    pass
 
 
 class User(UserBase):
     realm_type: Optional[str] = None
     tfa_locked_until: Optional[int] = None
-    tokens: Optional[list[dict]] = []
-    totp_locked: Optional[bool] = None
+    tokens: Optional[list[UserToken]] = []
+    totp_locked: Optional[int] = None
+
+
+class UserWithTokenDict(UserBase):
+    tokens: Optional[Dict[str, UserUniqueToken]] = None
+
+
+class UserTFAType(ProxmoxBaseModel):
+    realm: Literal["oauth", "yubico"]
+    types: list[Any]
+    user: Literal["oauth", "yubico"]

--- a/pyproxmox_ve/resources/access/users/users.py
+++ b/pyproxmox_ve/resources/access/users/users.py
@@ -4,7 +4,13 @@ from typing_extensions import TYPE_CHECKING
 from pyproxmox_ve.resources.base import BaseResourceAPI
 
 if TYPE_CHECKING:
-    from pyproxmox_ve.models.user import User
+    from pyproxmox_ve.models.user import (
+        User,
+        UserToken,
+        UserTokenResponse,
+        UserWithTokenDict,
+        UserTFAType,
+    )
 
 
 class AccessUsersAPI(BaseResourceAPI):
@@ -24,31 +30,139 @@ class AccessUsersAPI(BaseResourceAPI):
             params=self.api._build_params(enabled=enabled, full=full),
         )
 
-    async def get_user(self, username: str, realm: str) -> User | None:
+    async def get_user(self, user_id: str) -> UserWithTokenDict | None:
         """Gets a User.
 
         Args:
-            username:       Username of the User
-            realm:          Authentication Realm of the User
+            user_id:    User ID in the format of <username>@<realm>
         """
-        userid = f"{username}@{realm}"
         user = await self.api.query(
-            module_model=("pyproxmox_ve.models.user", "User"),
+            module_model=("pyproxmox_ve.models.user", "UserWithTokenDict"),
             method="GET",
-            endpoint=f"/access/users/{userid}",
+            endpoint=f"/access/users/{user_id}",
         )
 
         return user
 
-    async def create_user(self, username: str, realm: str, **kwargs) -> None:
+    async def create_user(self, user_id: str, **kwargs) -> None:
         """Creates a User.
 
         Args:
             user_id:    User ID in the format of <username>@<realm>
         """
-        kwargs.update({"userid": f"{username}@{realm}"})
+        kwargs.update({"userid": user_id})
         return await self.api.create(
             module_model=("pyproxmox_ve.models.user", "UserCreate"),
             endpoint="/access/users",
             obj_in=kwargs,
         )
+
+    async def update_user(self, user_id: str, **kwargs) -> None:
+        """Updates a User.
+
+        Args:
+            user_id:        User ID in the format of <username>@<realm>
+        """
+        return await self.api.update(
+            module_model=("pyproxmox_ve.models.user", "UserUpdate"),
+            endpoint=f"/access/users/{user_id}",
+            obj_in=kwargs,
+        )
+
+    async def delete_user(self, user_id: str) -> None:
+        """Deletes a User.
+
+        Args:
+            user_id:        User ID in the format of <username>@<realm>
+        """
+        return await self.api.delete(endpoint=f"/access/users/{user_id}")
+
+    async def get_user_tokens(self, user_id: str) -> list[UserToken]:
+        """Gets all user API tokens.
+
+        Args:
+            user_id:        User ID in the format of <username>@<realm>
+        """
+        return await self.api.query(
+            module_model=("pyproxmox_ve.models.user", "UserToken"),
+            method="GET",
+            endpoint=f"/access/users/{user_id}/token",
+        )
+
+    async def get_user_token(self, user_id: str, token_id: str) -> UserToken:
+        """Get a specific users API token.
+
+        Args:
+            user_id:        User ID in the format of <username>@<realm>
+            token_id:       Token ID
+        """
+        return await self.api.query(
+            module_model=("pyproxmox_ve.models.user", "UserToken"),
+            method="GET",
+            endpoint=f"/access/users/{user_id}/token/{token_id}",
+        )
+
+    async def create_user_token(
+        self, user_id: str, token_id: str, **kwargs
+    ) -> UserTokenResponse:
+        """Create an API token for a specific user.
+
+        Args:
+            user_id:        User ID in the format of <username>@<realm>
+            token_id:       Token ID
+        """
+        return await self.api.create(
+            module_model=("pyproxmox_ve.models.user", "UserToken"),
+            endpoint=f"/access/users/{user_id}/token/{token_id}",
+            obj_in=kwargs,
+            data_key="data",
+            validate_response=True,
+            response_model=("pyproxmox_ve.models.user", "UserTokenResponse"),
+        )
+
+    async def update_user_token(
+        self, user_id: str, token_id: str, **kwargs
+    ) -> UserToken:
+        """Get a specific users API token.
+
+        Args:
+            user_id:        User ID in the format of <username>@<realm>
+            token_id:       Token ID
+        """
+        return await self.api.update(
+            module_model=("pyproxmox_ve.models.user", "UserToken"),
+            endpoint=f"/access/users/{user_id}/token/{token_id}",
+            obj_in=kwargs,
+            validate_response=True,
+        )
+
+    async def delete_user_token(self, user_id: str, token_id: str) -> None:
+        """Deletes a specific users API token.
+
+        Args:
+            user_id:        User ID in the format of <username>@<realm>
+            token_id:       Token ID
+        """
+        return await self.api.delete(
+            endpoint=f"/access/users/{user_id}/token/{token_id}"
+        )
+
+    async def get_user_tfa_types(self, user_id: str) -> UserTFAType:
+        """Get a specific users TFA types
+
+        Args:
+            user_id:        User ID in the format of <username>@<realm>
+        """
+        return await self.api.query(
+            module_model=("pyproxmox_ve.models.user", "UserTFAType"),
+            method="GET",
+            endpoint=f"/access/users/{user_id}/tfa",
+        )
+
+    async def unlock_user_tfa(self, user_id: str) -> bool:
+        """Unlock a specific users TFA
+
+        Args:
+            user_id:        User ID in the format of <username>@<realm>
+        """
+        return await self.api.update(endpoint=f"/access/users/{user_id}/unlock-tfa")

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 minversion = 6.0
-addopts = -ra -q
+addopts = -ra -q --order-dependencies
 testpaths =
     tests
     integration

--- a/tests/access/test_users.py
+++ b/tests/access/test_users.py
@@ -1,3 +1,5 @@
+from uuid import uuid4
+
 import pytest
 from aiohttp import ClientResponseError
 
@@ -5,38 +7,96 @@ from pyproxmox_ve import ProxmoxVEAPI
 
 
 @pytest.mark.asyncio
-async def test_access_users_get_users(proxmox: ProxmoxVEAPI):
-    response = await proxmox.access.users.get_users(enabled=True, full=True)
-    assert isinstance(response, list)
-    assert len(response) > 0
+class TestAccessUsers:
+    async def test_get_users(self, proxmox: ProxmoxVEAPI):
+        response = await proxmox.access.users.get_users(enabled=True, full=True)
+        assert isinstance(response, list)
+        assert len(response) > 0
 
+    async def test_get_user_not_exist(self, proxmox: ProxmoxVEAPI):
+        with pytest.raises(ClientResponseError) as exc_info:
+            await proxmox.access.users.get_user(user_id="pyproxmox-ve-pytest@pam")
 
-@pytest.mark.asyncio
-async def test_access_users_get_user_not_exist(proxmox: ProxmoxVEAPI):
-    with pytest.raises(ClientResponseError) as exc_info:
-        await proxmox.access.users.get_user(username="pyproxmox-ve-pytest", realm="pam")
+        error = exc_info.value
+        assert error.status == 500
+        assert "no such user" in error.message
 
-    error = exc_info.value
-    assert error.status == 500
-    assert "no such user" in error.message
+    async def test_create_user(self, proxmox: ProxmoxVEAPI):
+        response = await proxmox.access.users.create_user(
+            user_id="pyproxmox-ve-pytest@pam",
+            comment="comment",
+            firstname="firstname",
+            lastname="lastname",
+        )
+        assert response
+        assert response.get("data") is None
 
+    async def test_get_user(self, proxmox: ProxmoxVEAPI):
+        user = await proxmox.access.users.get_user(user_id="pyproxmox-ve-pytest@pam")
+        assert user.enable == 1
+        assert user.expire == 0
+        assert user.comment == "comment"
+        assert user.firstname == "firstname"
+        assert user.lastname == "lastname"
 
-@pytest.mark.asyncio
-async def test_access_users_create_user(proxmox: ProxmoxVEAPI):
-    response = await proxmox.access.users.create_user(
-        username="pyproxmox-ve-pytest", realm="pam"
-    )
-    assert response
-    assert response.get("data") is None
+    async def test_create_user_exist(self, proxmox: ProxmoxVEAPI):
+        with pytest.raises(ClientResponseError) as exc_info:
+            await proxmox.access.users.create_user(user_id="pyproxmox-ve-pytest@pam")
 
+        error = exc_info.value
+        assert error.status == 500
+        assert "create user failed" in error.message
 
-@pytest.mark.asyncio
-async def test_access_users_create_user_exist(proxmox: ProxmoxVEAPI):
-    with pytest.raises(ClientResponseError) as exc_info:
-        await proxmox.access.users.create_user(
-            username="pyproxmox-ve-pytest", realm="pam"
+    async def test_update_user(self, proxmox: ProxmoxVEAPI):
+        uuid = str(uuid4())
+        await proxmox.access.users.update_user(
+            user_id="pyproxmox-ve-pytest@pam", comment=uuid
         )
 
-    error = exc_info.value
-    assert error.status == 500
-    assert "create user failed" in error.message
+        user = await proxmox.access.users.get_user(user_id="pyproxmox-ve-pytest@pam")
+        assert user
+        assert user.comment == uuid
+
+    async def test_delete_user_not_exist(self, proxmox: ProxmoxVEAPI):
+        with pytest.raises(ClientResponseError) as exc_info:
+            await proxmox.access.users.delete_user(
+                user_id="pyproxmox-ve-pytest-wrong@pam"
+            )
+
+        error = exc_info.value
+        assert error.status == 500
+        assert "no such user" in error.message
+
+    async def test_get_user_tfa_types(self, proxmox: ProxmoxVEAPI):
+        tfa_types = await proxmox.access.users.get_user_tfa_types(
+            user_id="pyproxmox-ve-pytest@pam"
+        )
+        assert (
+            tfa_types is None
+        )  # Enabling TFA type per user may be done via different API endpoint??
+
+    async def test_unlock_user_tfa(self, proxmox: ProxmoxVEAPI):
+        with pytest.raises(ClientResponseError) as exc_info:
+            await proxmox.access.users.unlock_user_tfa(
+                user_id="pyproxmox-ve-pytest-wrong@pam"
+            )
+
+        error = exc_info.value
+        assert error.status == 500
+        assert (
+            "no such user" in error.message
+        )  # May need to enable TFA first via a different endpoint for user to be recognized??
+
+    @pytest.mark.order(
+        after="test_users_token.py::TestAccessUsersToken::test_delete_user_token_not_exist"
+    )
+    async def test_delete_user(self, proxmox: ProxmoxVEAPI):
+        await proxmox.access.users.delete_user(user_id="pyproxmox-ve-pytest@pam")
+
+        # Check user no longer exist
+        with pytest.raises(ClientResponseError) as exc_info:
+            await proxmox.access.users.get_user(user_id="pyproxmox-ve-pytest@pam")
+
+        error = exc_info.value
+        assert error.status == 500
+        assert "no such user" in error.message

--- a/tests/access/test_users_token.py
+++ b/tests/access/test_users_token.py
@@ -1,0 +1,73 @@
+import pytest
+from aiohttp import ClientResponseError
+from datetime import datetime
+
+from pyproxmox_ve import ProxmoxVEAPI
+
+
+@pytest.mark.asyncio
+class TestAccessUsersToken:
+    async def test_get_user_tokens_not_exist(self, proxmox: ProxmoxVEAPI):
+        user_tokens = await proxmox.access.users.get_user_tokens(
+            user_id="pyproxmox-ve-pytest@pam"
+        )
+        assert user_tokens is None
+
+    async def test_create_user_token(self, proxmox: ProxmoxVEAPI):
+        token_response = await proxmox.access.users.create_user_token(
+            user_id="pyproxmox-ve-pytest@pam", token_id="pytest"
+        )
+        assert token_response
+        assert token_response.value
+        assert "pyproxmox-ve-pytest@pam" in token_response.full_tokenid
+
+    async def test_get_user_tokens(self, proxmox: ProxmoxVEAPI):
+        user_tokens = await proxmox.access.users.get_user_tokens(
+            user_id="pyproxmox-ve-pytest@pam"
+        )
+        assert user_tokens
+        assert len(user_tokens) > 0
+
+    async def test_get_user_check_token_dict(self, proxmox: ProxmoxVEAPI):
+        user = await proxmox.access.users.get_user(user_id="pyproxmox-ve-pytest@pam")
+        assert user
+        for token, token_data in user.tokens.items():
+            assert token
+            assert token_data.expire == 0
+            assert token_data.privsep == 1
+
+    async def test_get_user_token(self, proxmox: ProxmoxVEAPI):
+        user_token = await proxmox.access.users.get_user_token(
+            user_id="pyproxmox-ve-pytest@pam", token_id="pytest"
+        )
+        assert user_token
+        assert user_token.expire == 0
+        assert user_token.privsep == 1
+
+    async def test_update_user_token(self, proxmox: ProxmoxVEAPI):
+        epoch_update = int(datetime.utcnow().strftime("%s")) + 86400
+        await proxmox.access.users.update_user_token(
+            user_id="pyproxmox-ve-pytest@pam", token_id="pytest", expire=epoch_update
+        )
+
+        user_token_updated = await proxmox.access.users.get_user_token(
+            user_id="pyproxmox-ve-pytest@pam", token_id="pytest"
+        )
+
+        assert user_token_updated
+        assert user_token_updated.expire == epoch_update
+
+    async def test_delete_user_token(self, proxmox: ProxmoxVEAPI):
+        await proxmox.access.users.delete_user_token(
+            user_id="pyproxmox-ve-pytest@pam", token_id="pytest"
+        )
+
+    async def test_delete_user_token_not_exist(self, proxmox: ProxmoxVEAPI):
+        with pytest.raises(ClientResponseError) as exc_info:
+            await proxmox.access.users.delete_user_token(
+                user_id="pyproxmox-ve-pytest@pam", token_id="pytest"
+            )
+
+        error = exc_info.value
+        assert error.status == 500
+        assert "no such token" in error.message

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,13 +45,6 @@ def pytest_addoption(parser):
         help="API Token for ProxmoxVE API",
         default="0d06e68c-930c-4d5f-bad5-9c18de0d85bf",
     )
-    parser.addoption(
-        "--use-pydantic",
-        action="store_true",
-        dest="use_pydantic",
-        help="Use Pydantic to validate input and output when interacting with the ProxmoxVE API",
-        default=False,
-    )
 
 
 @pytest.fixture
@@ -70,7 +63,6 @@ def proxmox(event_loop, request: FixtureRequest) -> ProxmoxVEAPI:
     realm = request.config.getoption("realm")
     api_token_id = request.config.getoption("api_token_id")
     api_token = request.config.getoption("api_token")
-    use_pydantic = request.config.getoption("use_pydantic")
 
     async def _make_api_obj():
         return ProxmoxVEAPI(
@@ -79,7 +71,7 @@ def proxmox(event_loop, request: FixtureRequest) -> ProxmoxVEAPI:
             realm=realm,
             api_token_id=api_token_id,
             api_token=api_token,
-            use_pydantic=use_pydantic,
+            use_pydantic=True,
         )
 
     api = event_loop.run_until_complete(_make_api_obj())

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -5,4 +5,7 @@ import pytest
 @pytest.mark.asyncio
 async def test_version_endpoint(proxmox: ProxmoxVEAPI):
     response = await proxmox.version.get_version()
-    print(response)
+    assert response
+    assert response.version
+    assert response.repoid
+    assert response.release


### PR DESCRIPTION
This merge request implements all endpoints for the /access/users group of endpoints

There are also a lot of changes for pytest which will be documented in the next merge request as this sets the baseline of pytests for the rest of the project for now during the initial development until we revisit it if need be.

closes #5 