### PR TITLE
19 custom exceptions

### DIFF
--- a/docs/how_to_use_basic.md
+++ b/docs/how_to_use_basic.md
@@ -41,3 +41,6 @@ Currently, all responses that return a status code of 400 or higher will raise a
 # Bad Token Example
 > aiohttp.client_exceptions.ClientResponseError: 401, message='invalid token value!', url=URL('https://192.0.2.100:8006/api2/json/version')
 ```
+
+!!! note
+    If you would like to not use the custom exceptions provided by this module, set `raise_exceptions` to False when initializing `ProxmoxVEAPI` and this will simply raise aiohttp ClientResponseError exceptions when Proxmox API returns a status code of `400` or higher. However using the inbuilt exceptions should improve both the troubleshooting and developer experience.

--- a/pyproxmox_ve/exceptions.py
+++ b/pyproxmox_ve/exceptions.py
@@ -1,3 +1,12 @@
+class ProxmoxAPIResponseError(Exception):
+    def __init__(self, status: int, reason: str, errors: dict):
+        self.status = status
+        self.reason = reason
+        self.errors = errors
+
+        super().__init__(f"[{self.status}] {self.reason} - API Errors: {self.errors}")
+
+
 class ProxmoxAPIAuthenticationError(Exception):
     def __init__(self):
         super().__init__("Authentication Error (No ticket or API key).")

--- a/pyproxmox_ve/models/access.py
+++ b/pyproxmox_ve/models/access.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 from pydantic import Field
 
-from pyproxmox_ve.models.base import ProxmoxBaseModel
+from pyproxmox_ve.models.base import ProxmoxBaseModel, ProxmoxBaseModelWithoutAlias
 from pyproxmox_ve.models.enums import (
     AccessACLEnum,
     DomainTypeEnum,
@@ -60,25 +60,25 @@ class Domain(ProxmoxBaseModel):
     tfa: Optional[TFAEnum] = None
 
 
-class DomainCreate(ProxmoxBaseModel):
+class DomainCreate(ProxmoxBaseModelWithoutAlias):
     realm: str
     type: DomainTypeEnum
-    acr_values: Optional[str] = None
-    autocreate: Optional[bool] = False
+    acr_values: Optional[str] = Field(None, serialization_alias="acr-values")
+    autocreate: Optional[bool] = None
     base_dn: Optional[str] = None
     bind_dn: Optional[str] = None
     capath: Optional[str] = "/etc/ssl/certs"
-    case_sensitive: Optional[bool] = True
+    case_sensitive: Optional[bool] = Field(1, serialization_alias="case-sensitive")
     cert: Optional[str] = None
     certkey: Optional[str] = None
-    check_connection: Optional[bool] = False
+    check_connection: Optional[bool] = Field(0, serialization_alias="check-connection")
     client_id: Optional[str] = None
     client_key: Optional[str] = None
     comment: Optional[str] = None
     default: Optional[bool] = None
     domain: Optional[str] = None
     filter: Optional[str] = None
-    group_classes: Optional[str] = "groupOfNames, group, univent..."
+    group_classes: Optional[str] = None
     group_dn: Optional[str] = None
     group_filter: Optional[str] = None
     group_name_attr: Optional[str] = None
@@ -87,7 +87,7 @@ class DomainCreate(ProxmoxBaseModel):
     password: Optional[str] = None
     port: Optional[int] = None
     prompt: Optional[str] = None
-    scopes: Optional[str] = "email profile"
+    scopes: Optional[str] = None
     secure: Optional[bool] = None
     server1: Optional[str] = None
     server2: Optional[str] = None
@@ -98,4 +98,4 @@ class DomainCreate(ProxmoxBaseModel):
     user_attr: Optional[str] = None
     user_classes: Optional[str] = None
     username_claim: Optional[str] = None
-    verify: Optional[bool] = False
+    verify: Optional[bool] = 0

--- a/pyproxmox_ve/models/base.py
+++ b/pyproxmox_ve/models/base.py
@@ -11,3 +11,12 @@ class ProxmoxBaseModel(BaseModel):
         alias_generator=normalize_keys,
         use_enum_values=True,
     )
+
+
+class ProxmoxBaseModelWithoutAlias(BaseModel):
+    """Use this class when most attributes shouldn't be serialized using alias generator."""
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        use_enum_values=True,
+    )

--- a/tests/access/test_access.py
+++ b/tests/access/test_access.py
@@ -1,7 +1,7 @@
 import pytest
-from aiohttp import ClientResponseError
 
 from pyproxmox_ve import ProxmoxVEAPI
+from pyproxmox_ve.exceptions import ProxmoxAPIResponseError
 
 
 @pytest.mark.asyncio
@@ -34,14 +34,14 @@ class TestAccess:
 
     async def test_update_password(self, proxmox: ProxmoxVEAPI):
         # This endpoint is not available for API tokens.
-        with pytest.raises(ClientResponseError) as exc_info:
+        with pytest.raises(ProxmoxAPIResponseError) as exc_info:
             await proxmox.access.update_password(
                 user_id="pyproxmox-ve-pytest@pam", password="fakepassword123!"
             )
 
             error = exc_info.value
             assert error.status == 403
-            assert "need proper ticket" in error.message
+            assert "need proper ticket" in error.reason
 
     async def test_get_permissions(self, proxmox: ProxmoxVEAPI):
         response = await proxmox.access.get_permissions(path="/access")

--- a/tests/access/test_access_domains.py
+++ b/tests/access/test_access_domains.py
@@ -14,15 +14,14 @@ class TestAccessDomains:
         assert response
         assert len(response) > 0
 
-    """
     async def test_create_domain(self, proxmox: ProxmoxVEAPI):
-        response = await proxmox.access.domains.create_domain(
+        await proxmox.access.domains.create_domain(
             realm="pytest-ldap",
             realm_type="ldap",
             server="192.0.2.100",
             base_domain_name="pytest",
-            user_attr="uid",
             mode="ldap",
+            server1="192.0.2.100",
+            user_attr="uid",
+            base_dn="CN=pyproxmox_ve,DC=pyproxmox_ve,DC=github,DC=io",
         )
-        print(response)
-    """

--- a/tests/access/test_users_token.py
+++ b/tests/access/test_users_token.py
@@ -1,9 +1,9 @@
 from datetime import datetime
 
 import pytest
-from aiohttp import ClientResponseError
 
 from pyproxmox_ve import ProxmoxVEAPI
+from pyproxmox_ve.exceptions import ProxmoxAPIResponseError
 
 
 @pytest.mark.asyncio
@@ -67,11 +67,11 @@ class TestAccessUsersToken:
         )
 
     async def test_delete_user_token_not_exist(self, proxmox: ProxmoxVEAPI):
-        with pytest.raises(ClientResponseError) as exc_info:
+        with pytest.raises(ProxmoxAPIResponseError) as exc_info:
             await proxmox.access.users.delete_user_token(
                 user_id="pyproxmox-ve-pytest@pam", token_id="pytest"
             )
 
         error = exc_info.value
         assert error.status == 500
-        assert "no such token" in error.message
+        assert "no such token" in error.reason

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,6 +71,7 @@ async def proxmox(request: FixtureRequest) -> ProxmoxVEAPI:
         api_token_id=api_token_id,
         api_token=api_token if not use_cookie_auth else None,
         use_pydantic=True,
+        raise_exceptions=True,  # Always explicitly raise custom exceptions during pytest
     )
 
     if use_cookie_auth:


### PR DESCRIPTION
Closes #19 for now, may reopen when I figure out the best way to catch more specific errors based on the response code/message.

ProxmoxAPI sends generic return codes, with different status explaining the issue.

eg. 500 no user exist vs 500 no auth domain exist